### PR TITLE
Provisioning scripts for vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ Project to run the whole ggtracker stack in vagrant
 
 ### Running
  * Make sure you have vagrant+virtualbox installed on your computer
- * Run `vagrant up` to create the virtual box
+ * Run `git submodule update --init` to pull submodules
+ * Run `vagrant up` to create the virtual box. This will download all required packages and go through the installation process for ggtracker and ESDB (~15 minutes; go make yourself a sandwich)
  * Run `vagrant ssh` to ssh into the vagrant box
- * Find code in /vagrant
- * Run the installation and updating steps of the components (ESDB and ggtracker) ([will be automated soon](https://github.com/gravelweb/ggtrackerstack/commit/e3bdbb30d9384d37e8b96692af81cefd5f8a87d2))
-   * ESDB: https://github.com/dsjoerg/esdb#installation-and-setup
-   * ggtracker: https://github.com/dsjoerg/ggtracker#basic-installation-and-updating
-     * Note: You need to run ggtracker webapp like this `ESDB_HOST=172.28.128.3:9292 foreman start` (change ip accordingly)
+ * Find code in /vagrant `cd /vagrant`
+ * Start the application (requires 2 ssh sessions, or run them as background jobs)
+   * ESDB: `(cd esdb && foreman start)`
+   * ggtracker: `(cd ggtracker && ESDB_HOST=172.28.128.3:9292 foreman start)` (change IP accordingly)
  * Set up Amazon AWS S3 buckets for development as described in [esdb/config/s3.yml.example](https://github.com/dsjoerg/esdb/blob/master/config/s3.yml.example) (only dev and test are needed) and set up buckets and credentials accordingly in `esdb/config/s3.yml`.
  * Set up a hostname for the vagrant box's ip in /etc/hosts - e.g. `172.28.128.3 ggtracker.test` (change ip accordingly)
  * The app will be on `ggtracker.test` in the browser and uploading should work - otherwise please raise an issue here, so it can be fixed.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "ggtrackerstack"
 
   config.vm.provision "shell", path: "setup-vagrantbox.sh"
+  config.vm.provision "shell", path: "install-ggtrackerstack.sh", privileged: false
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 1536

--- a/install-ggtrackerstack.sh
+++ b/install-ggtrackerstack.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+cd /vagrant
+
+
+echo INSTALLING GGTRACKER
+# install ggtracker
+(cd ggtracker && \
+  bundle && \
+  cp -np config/secrets.yml{.example,} && \
+  cp -np config/s3.yml{.example,} && \
+  rake db:create && \
+  bundle exec rake db:schema:load)
+
+echo INSTALLING ESDB
+(cd esdb && \
+  cp -np config/database.yml{.example,} && \
+  bundle && \
+  (mysql -u root <<-"EOF"
+	create database if not exists esdb_development;
+	create database if not exists esdb_test;
+EOF
+) && \
+  cp -np config/s3.yml{.example,} && \
+  cp -np config/fog.rb{.example,} && \
+  cp -np config/redis.yml{.example,} && \
+  cp -np config/esdb.yml{.example,} && \
+  cp -np config/tokens.yml{.example,} && \
+  bundle exec sequel -m db/migrations -e development config/database.yml && \
+  cat db/replays_sq_skill_stat.sql | mysql -u root -D esdb_development && \
+  cat db/ggtracker_provider.sql | mysql -u root -D esdb_development && \
+  bundle exec rake py:init && \
+  bundle exec sequel -m db/migrations -e test config/database.yml && \
+  echo RUNNING TESTS && \
+  bundle exec rspec)
+
+echo DONE install-ggtrackerstack.sh

--- a/setup-vagrantbox.sh
+++ b/setup-vagrantbox.sh
@@ -6,10 +6,20 @@ add-apt-repository ppa:chris-lea/redis-server -y
 
 apt-get update
 
-apt-get install -y ruby redis-server nodejs npm mysql-server git-core ruby-dev libcurl4-openssl-dev libmysqlclient-dev build-essential libxml2-dev libxslt-dev memcached imagemagick libsasl2-dev python-pip python-dev libtiff5-dev libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python-tk 
+# GGTRACKER dependencies
+apt-get install -y \
+  ruby redis-server nodejs npm mysql-server git-core ruby-dev \
+  libcurl4-openssl-dev libmysqlclient-dev build-essential libxml2-dev \
+  libxslt-dev
+
+# ESDB dependencies
+apt-get install -y \
+  memcached imagemagick libsasl2-dev python-pip python-dev libtiff5-dev \
+  libjpeg8-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev \
+  tk8.6-dev python-tk
 
 gem install bundler
 npm install -g juggernaut
 
-# Juggetnaut looks for `node` instead of `nodejs`
+# Juggernaut looks for `node` instead of `nodejs`
 sudo ln -s /usr/bin/nodejs /usr/bin/node

--- a/setup-vagrantbox.sh
+++ b/setup-vagrantbox.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 export DEBIAN_FRONTEND=noninteractive
 
 add-apt-repository ppa:chris-lea/redis-server -y


### PR DESCRIPTION
Tested this from clean, and reruning from `vagrant ssh` via `cd /vagrant && bash install-ggtrackerstack.sh`.

Depends on two other pull requests:
https://github.com/nickelsen/ggtracker/pull/2
https://github.com/nickelsen/esdb/pull/1
